### PR TITLE
Stopping header row from showing as data (when <thead> is not defined)

### DIFF
--- a/stacktable.js
+++ b/stacktable.js
@@ -44,7 +44,7 @@
       $table.siblings().filter('.small-only').remove();
 
       // using rowIndex and cellIndex in order to reduce ambiguity
-      $table.find('>tbody>tr').each(function() {
+      $table.find('>tbody>tr').not($topRow).each(function() {
 
         // declaring headMarkup and bodyMarkup, to be used for separately head and body of single records
         headMarkup = '';


### PR DESCRIPTION
I've noticed that when no <thead> is defined, the top row can appear like so:
![image](https://user-images.githubusercontent.com/13779889/27122942-9b8a16aa-512f-11e7-911e-9a2d6b879150.png)
This fix will make it ignore the header row when processing the data for the table.