### PR TITLE
Add stacktable.css to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "http://johnpolacek.github.com/stacktable.js/",
   "files": [
-    "stacktable.js"
+    "stacktable.js",
+    "stacktable.css"
   ]
 }


### PR DESCRIPTION
We use the stacktable.css file with our projects. It was included fine when using bower, but it is not included when installing via npm. This seems to fix the issue.