### PR TITLE
Fix project page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stacktable.js
 
-The Responsive Tables jQuery plugin for stacking tables on small screens. The purpose of stacktable.js is to give you an easy way of converting wide tables to a format that will work better on small screens. It creates a copy of the table that is converted into a 2-column key/value format. For more info, go to [the project page](http://johnpolacek.github.com/stacktable.js).
+The Responsive Tables jQuery plugin for stacking tables on small screens. The purpose of stacktable.js is to give you an easy way of converting wide tables to a format that will work better on small screens. It creates a copy of the table that is converted into a 2-column key/value format. For more info, go to [the project page](http://johnpolacek.github.io/stacktable.js).
 
 [Follow me on Twitter](http://twitter.com/johnpolacek)
 


### PR DESCRIPTION
This PR updates the project README to point to `*.github.io` instead of `*.github.com`. The `.com` URL returns a 404.